### PR TITLE
Add telemetry data for tsd instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ variables that control cleanup process:
 * `TSD_CACHE_CLEANUP_INTERVAL` interval between cleanups in seconds
 * `TSD_CACHE_MAX_AGE_MINUTES` max age of cache files in minutes
 
+## TSD telemetry
+
+Setting `TSD_TELEMETRY_INTERVAL` to some positive value enables feeding
+TSD metrics back to OpenTSDB. Value for `host` tag will be taken from
+`MESOS_TASK_ID` if possible or from `hostname -s` output.
+
 ## Running ad-hoc OpenTSDB commands
 
 If you supply any args to the image, they will be passed to `tsdb` executable.

--- a/unprivileged.sh
+++ b/unprivileged.sh
@@ -12,6 +12,21 @@ export TSD_CACHE_MAX_AGE_MINUTES=${TSD_CACHE_MAX_AGE_MINUTES:-60}
     echo "[$(date)] Cache cleanup complete"
 done) &
 
+# Feeding opentsdb metrics back to itself
+if [ "${TSD_TELEMETRY_INTERVAL:-0}" != "0" ]; then
+    TSD_BIND=${TSD_CONF_tsd__network__bind:-127.0.0.1}
+    TSD_PORT=${TSD_CONF_tsd__network__port}
+    TSD_HOST=${MESOS_TASK_ID:-$(hostname -s)}
+
+    (while true; do
+        sleep "${TSD_TELEMETRY_INTERVAL}"
+        echo "[$(date)] Writing own metrics"
+        curl -s "http://$TSD_BIND:$TSD_PORT/api/stats" | \
+          sed -e "s#\"host\":\"[^\"]*\"#\"host\":\"$TSD_HOST\"#g" | \
+          curl -s -X POST -H "Content-type: application/json" "http://$TSD_BIND:$TSD_PORT/api/put" -d @-
+    done) &
+fi
+
 if [ "${1}" = "" ]; then
     exec /opt/opentsdb/build/tsdb tsd --config /opt/opentsdb/src/opentsdb.conf
 fi


### PR DESCRIPTION
This enables optional telemetry logging for TSD instances. If enabled, it checks own metrics periodically and sends them back to OpenTSDB. When launched on Mesos, `MESOS_TASK_ID` is used instead as the value for `host` tag.

cc @alberts @dqminh 
